### PR TITLE
Refactor sample loading and harden error handling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,147 +1,11 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Teleprompter from "@/components/Teleprompter";
 import FileTextInput from "@/components/FileTextInput";
 import HelpPanel from "@/components/HelpPanel";
 import { messages, normalizeUILang } from "@/lib/i18n";
 
-const SAMPLE_IT = `Signore e Signori,
-è con grande piacere che vi parlo oggi del lavoro che svolge APPLiA.
-
-APPLiA è l’associazione che rappresenta l’industria degli elettrodomestici in Europa.
-Il nostro settore impiega direttamente oltre 200.000 persone,
-e indirettamente sostiene milioni di posti di lavoro lungo la catena del valore.
-
-La nostra missione è semplice ma ambiziosa:
-promuovere l’innovazione, la sostenibilità e la competitività delle imprese europee.
-
-Lavoriamo ogni giorno con le istituzioni europee,
-con i governi nazionali, e con le organizzazioni della società civile.
-Il nostro obiettivo è portare la voce di un settore essenziale,
-che accompagna la vita quotidiana di centinaia di milioni di cittadini europei.
-
-Oggi desidero concentrare la mia attenzione su un segmento specifico:
-gli apparecchi di raffreddamento, o cooling appliances.
-
-La domanda globale di questi prodotti è in forte crescita.
-Le ragioni sono molteplici:
-l’aumento della popolazione mondiale,
-il miglioramento del livello di vita in numerose regioni emergenti,
-e naturalmente il cambiamento climatico,
-che porta a estati sempre più calde e prolungate.
-
-Guardando all’Europa,
-possiamo osservare tendenze simili ma con alcune peculiarità.
-Da un lato, i consumatori europei chiedono apparecchi sempre più efficienti,
-che riducano i consumi energetici e le bollette.
-Dall’altro lato, i legislatori europei fissano standard molto severi,
-per garantire la sicurezza e la sostenibilità ambientale.
-
-Ed è proprio sul quadro legislativo che dobbiamo soffermarci.
-La normativa sugli F-gas, ad esempio,
-impone restrizioni significative sull’uso di gas fluorurati,
-fondamentali per il funzionamento di molti sistemi di raffreddamento.
-
-Un altro fronte delicato riguarda i PFAS,
-le cosiddette “sostanze per sempre”.
-L’ipotesi di un divieto totale solleva interrogativi importanti,
-perché molte applicazioni industriali ancora non dispongono di alternative valide.
-
-Tuttavia, vi sono anche prospettive positive.
-Il piano RePower EU, ad esempio,
-spinge verso un’accelerazione della transizione energetica,
-offrendo opportunità per apparecchi più efficienti
-e per tecnologie innovative che possano ridurre le emissioni complessive.
-
-In questo contesto complesso,
-qual è la via da seguire per un’associazione come APPLiA?
-
-La nostra risposta è chiara:
-dialogo costante con le istituzioni,
-collaborazione con tutte le parti interessate,
-e impegno per garantire che la sostenibilità vada di pari passo con la competitività.
-
-Difendere la produzione europea non significa chiedere protezionismo,
-ma creare un terreno equo in cui le aziende europee
-possano continuare a investire in innovazione e occupazione.
-
-Il nostro settore ha dimostrato di saper cambiare,
-di saper investire nella digitalizzazione e nell’efficienza energetica,
-e continuerà a farlo.
-
-APPLiA sarà sempre al fianco delle istituzioni e dei cittadini,
-per costruire insieme un futuro più verde,
-più sicuro e più prospero per l’Europa.
-
-Grazie per la vostra attenzione.`;
-const SAMPLE_EN = `Ladies and Gentlemen,
-it is a great pleasure to address you today about the work carried out by APPLiA.
-
-APPLiA is the association representing the home appliance industry in Europe.
-Our sector directly employs more than 200,000 people,
-and indirectly supports millions of jobs across the value chain.
-
-Our mission is simple yet ambitious:
-to promote innovation, sustainability, and competitiveness.
-
-We work every day with European institutions,
-with national governments, and with civil society organizations.
-Our goal is to bring the voice of an essential sector,
-one that touches the everyday life of hundreds of millions of European citizens.
-
-Today, I would like to focus on a specific segment:
-cooling appliances.
-
-The global demand for these products is rapidly increasing.
-There are many reasons for this:
-the growth of the world’s population,
-the rising living standards in many emerging regions,
-and of course, climate change,
-which brings longer and hotter summers.
-
-Looking at Europe,
-we see similar trends, but also some unique characteristics.
-On the one hand, European consumers ask for ever more efficient appliances,
-capable of reducing energy consumption and household bills.
-On the other hand, European legislators set strict standards,
-to ensure both safety and environmental sustainability.
-
-It is therefore necessary to consider the legislative framework.
-The F-gas regulation, for example,
-imposes significant restrictions on the use of fluorinated gases,
-which are essential to the functioning of many cooling systems.
-
-Another sensitive topic concerns PFAS,
-the so-called “forever chemicals”.
-The idea of a full ban raises important questions,
-as many industrial applications still lack viable alternatives.
-
-Yet, there are also positive perspectives.
-The RePower EU plan, for instance,
-accelerates the energy transition,
-creating opportunities for more efficient appliances
-and for innovative technologies to reduce overall emissions.
-
-In such a complex environment,
-what is the way forward for an association like APPLiA?
-
-Our answer is clear:
-a constant dialogue with institutions,
-a collaborative approach with all stakeholders,
-and a firm commitment to ensure that sustainability goes hand in hand with competitiveness.
-
-Defending European manufacturing does not mean asking for protectionism.
-It means creating a level playing field,
-where European companies can continue to invest in innovation and employment.
-
-Our sector has shown its ability to adapt,
-to invest in digitalisation and in energy efficiency,
-and it will continue to do so.
-
-APPLiA will remain by the side of institutions and citizens,
-to build together a greener, safer, and more prosperous future for Europe.
-
-Thank you for your attention.`;
+type SampleTexts = { it?: string; en?: string };
 
 export default function Home() {
   const [lang, setLang] = useState<string>("it-IT");
@@ -151,38 +15,57 @@ export default function Home() {
     baseWpm: 140,
     holdOnSilence: true,
   });
+  const [samples, setSamples] = useState<SampleTexts>({});
+  const [text, setText] = useState("");
+  const fetchSample = useCallback(async (l: "it" | "en") => {
+    try {
+      const res = await fetch(`/samples/${l}.txt`);
+      const txt = await res.text();
+      setSamples((s) => ({ ...s, [l]: txt }));
+      return txt;
+    } catch (err) {
+      console.error("Failed to load sample", err);
+      return "";
+    }
+  }, []);
   useEffect(() => {
     // Initialize from localStorage or browser language on first mount
     try {
       const savedLang = localStorage.getItem("tp:lang");
       const l = savedLang || (typeof navigator !== "undefined" ? navigator.language : "it-IT");
       setLang(l);
-    } catch {}
+    } catch (err) {
+      console.error("Failed to load language", err);
+    }
     try {
       const raw = localStorage.getItem("tp:settings");
       if (raw) {
         const parsed = JSON.parse(raw);
         setSettings((s) => ({ ...s, ...parsed }));
       }
-    } catch {}
-  }, []);
+    } catch (err) {
+      console.error("Failed to load settings", err);
+    }
+    fetchSample("it").then(setText);
+  }, [fetchSample]);
   const ui = messages[normalizeUILang(lang)];
-  const [text, setText] = useState(SAMPLE_IT);
   useEffect(() => {
-    // Swap sample text when language changes only if current text is exactly one of the samples
-    setText((prev) => {
-      if (prev === SAMPLE_IT || prev === SAMPLE_EN) {
-        return normalizeUILang(lang) === "it" ? SAMPLE_IT : SAMPLE_EN;
-      }
-      return prev;
-    });
-  }, [lang]);
+    const norm = normalizeUILang(lang) as "it" | "en";
+    const swap = (txt: string) =>
+      setText((prev) => (prev === samples.it || prev === samples.en ? txt : prev));
+    if (samples[norm]) swap(samples[norm]!);
+    else fetchSample(norm).then(swap);
+  }, [lang, samples, fetchSample]);
   // Persist settings and language
   useEffect(() => {
-    try { localStorage.setItem("tp:lang", lang); } catch {}
+    try { localStorage.setItem("tp:lang", lang); } catch (err) {
+      console.error("Failed to save language", err);
+    }
   }, [lang]);
   useEffect(() => {
-    try { localStorage.setItem("tp:settings", JSON.stringify(settings)); } catch {}
+    try { localStorage.setItem("tp:settings", JSON.stringify(settings)); } catch (err) {
+      console.error("Failed to save settings", err);
+    }
   }, [settings]);
 
   // Keyboard shortcuts at page level: m (mirror), +/- (font size)
@@ -233,7 +116,12 @@ export default function Home() {
         <FileTextInput onLoadText={setText} lang={lang} />
         <button
           className="px-3 py-1 rounded bg-neutral-200 hover:bg-neutral-300 text-sm"
-          onClick={() => setText(normalizeUILang(lang) === "it" ? SAMPLE_IT : SAMPLE_EN)}
+          onClick={() => {
+            const norm = normalizeUILang(lang) as "it" | "en";
+            const existing = samples[norm];
+            if (existing) setText(existing);
+            else fetchSample(norm).then(setText);
+          }}
           type="button"
         >
           {ui.loadDemo}

--- a/components/FileTextInput.tsx
+++ b/components/FileTextInput.tsx
@@ -1,78 +1,7 @@
 "use client";
 import { useRef } from "react";
 import { messages, normalizeUILang } from "@/lib/i18n";
-
-function hexToChar(_: string, h: string) {
-  try { return String.fromCharCode(parseInt(h, 16)); } catch { return ""; }
-}
-
-function rtfToText(rtf: string) {
-  // Decode hex escapes first (\'hh)
-  let s = rtf.replace(/\\'([0-9a-fA-F]{2})/g, hexToChar);
-  // Map structural controls to whitespace before stripping
-  s = s
-    .replace(/\\par[d]?\b/g, "\n")
-    .replace(/\\line\b/g, "\n")
-    .replace(/\\tab\b/g, "\t");
-  // Unescape special chars
-  s = s.replace(/\\\\/g, "\\").replace(/\\\{/g, "{").replace(/\\\}/g, "}");
-  // Drop remaining control words (e.g., \b, \fs24, \cf1)
-  s = s.replace(/\\[a-zA-Z]+-?\d* ?/g, "");
-  // Remove groups braces
-  s = s.replace(/[{}]/g, "");
-  // Normalize whitespace
-  s = s.replace(/\r\n?|\r/g, "\n");
-  s = s.replace(/[\t ]+\n/g, "\n");
-  s = s.replace(/\n{3,}/g, "\n\n");
-  return s.trim();
-}
-
-function srtToText(srt: string) {
-  const lines = srt.split(/\r?\n/);
-  const out: string[] = [];
-  const timeRe = /^\s*\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/;
-  for (const line of lines) {
-    if (/^\s*\d+\s*$/.test(line)) continue; // index line
-    if (timeRe.test(line)) continue; // timecode line
-    out.push(line);
-  }
-  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
-}
-
-function mdToText(md: string) {
-  let s = md;
-  // Remove code fences and inline code ticks (keep content inline)
-  s = s.replace(/```[\s\S]*?```/g, (m) => m.replace(/```/g, ""));
-  s = s.replace(/`([^`]*)`/g, "$1");
-  // Images: ![alt](url) -> alt
-  s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
-  // Links: [text](url) -> text
-  s = s.replace(/\[([^\]]+)\]\((?:[^)]+)\)/g, "$1");
-  // Headings: #### Title -> Title
-  s = s.replace(/^\s{0,3}#{1,6}\s+/gm, "");
-  // Blockquotes: > text -> text
-  s = s.replace(/^\s{0,3}>\s?/gm, "");
-  // Lists: -/*/+ or 1. -> text
-  s = s.replace(/^\s{0,3}([*+-]|\d+\.)\s+/gm, "");
-  // Emphasis/strong/strike: *text* **text** _text_ __text__ ~~text~~ -> text
-  s = s.replace(/([*_~]{1,2})([^*_~]+)\1/g, "$2");
-  // Horizontal rules
-  s = s.replace(/^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/gm, "");
-  // Strip simple HTML tags
-  s = s.replace(/<[^>]+>/g, "");
-  // Normalize whitespace
-  s = s.replace(/\r\n?|\r/g, "\n").replace(/\n{3,}/g, "\n\n");
-  return s.trim();
-}
-
-async function extractTextFromFile(file: File): Promise<string> {
-  const raw = await file.text();
-  const name = file.name.toLowerCase();
-  if (name.endsWith(".rtf")) return rtfToText(raw);
-  if (name.endsWith(".srt")) return srtToText(raw);
-  if (name.endsWith(".md") || name.endsWith(".markdown")) return mdToText(raw);
-  return raw;
-}
+import { extractTextFromFile } from "@/lib/textConverters";
 
 export default function FileTextInput({ onLoadText, lang }: { onLoadText: (text: string) => void; lang?: string; }) {
   const ui = messages[normalizeUILang(lang)];

--- a/components/HelpPanel.tsx
+++ b/components/HelpPanel.tsx
@@ -18,7 +18,8 @@ export default function HelpPanel({ lang }: { lang?: string }) {
       const w = typeof window !== "undefined" ? window : undefined;
       const asr = !!(w && ("SpeechRecognition" in w || "webkitSpeechRecognition" in w));
       setEnv({ secure, mic, asr });
-    } catch {
+    } catch (err) {
+      console.error("Failed to detect environment features", err);
       setEnv({ secure: false, mic: false, asr: false });
     }
   }, []);

--- a/components/Teleprompter.tsx
+++ b/components/Teleprompter.tsx
@@ -161,7 +161,9 @@ export default function Teleprompter({ text, baseWpm = 140, holdOnSilence = true
     wordsReadRef.current = 0;
     integratorRef.current = 0;
     if (containerRef.current) containerRef.current.scrollTop = 0;
-    try { resetASR(); } catch {}
+    try { resetASR(); } catch (err) {
+      console.error("Failed to reset ASR", err);
+    }
   };
 
   // Avoid hydration mismatch: detect client and feature support after mount
@@ -176,7 +178,8 @@ export default function Teleprompter({ text, baseWpm = 140, holdOnSilence = true
         ("webkitGetUserMedia" in nav) || ("mozGetUserMedia" in nav) || ("getUserMedia" in nav))
       );
       setMicSupported(supported);
-    } catch {
+    } catch (err) {
+      console.error("Failed to detect mic support", err);
       setMicSupported(false);
     }
   }, []);
@@ -363,9 +366,11 @@ export default function Teleprompter({ text, baseWpm = 140, holdOnSilence = true
         const cont = containerRef.current;
         if (!cont) return;
         if (document.fullscreenElement) {
-          document.exitFullscreen().catch(() => {});
+          document.exitFullscreen().catch((err) => console.error("Failed to exit fullscreen", err));
         } else {
-          try { cont.requestFullscreen(); } catch {}
+          try { cont.requestFullscreen(); } catch (err) {
+            console.error("Failed to request fullscreen", err);
+          }
         }
       }
     };
@@ -410,9 +415,11 @@ export default function Teleprompter({ text, baseWpm = 140, holdOnSilence = true
               const cont = containerRef.current;
               if (!cont) return;
               if (document.fullscreenElement) {
-                document.exitFullscreen().catch(() => {});
+                document.exitFullscreen().catch((err) => console.error("Failed to exit fullscreen", err));
               } else {
-                try { cont.requestFullscreen(); } catch {}
+                try { cont.requestFullscreen(); } catch (err) {
+                  console.error("Failed to request fullscreen", err);
+                }
               }
             }}
             className="p-2 rounded bg-neutral-700 hover:bg-neutral-600 text-white"

--- a/hooks/useMicSpeechRate.ts
+++ b/hooks/useMicSpeechRate.ts
@@ -161,13 +161,15 @@ export function useMicSpeechRate(opts?: {
       rafRef.current = null;
     }
     if (audioCtxRef.current) {
-      audioCtxRef.current.close().catch(()=>{});
+      audioCtxRef.current.close().catch((err) => console.error("Failed to close audio context", err));
       audioCtxRef.current = null;
     }
     if (mediaStreamRef.current) {
       try {
         mediaStreamRef.current.getTracks().forEach(t => t.stop());
-      } catch {}
+      } catch (err) {
+        console.error("Failed to stop media tracks", err);
+      }
       mediaStreamRef.current = null;
     }
     analyserRef.current = null;

--- a/hooks/useSpeechSync.ts
+++ b/hooks/useSpeechSync.ts
@@ -149,7 +149,9 @@ export function useSpeechSync(opts: { text: string; lang?: string; enabled?: boo
         const err = e?.error || e?.message || String(e?.type || "error");
         setLastError(err);
         console.warn("ASR error:", err);
-      } catch {}
+      } catch (error) {
+        console.error("Failed to handle ASR error", error);
+      }
       // Swallow errors; try to restart once the engine ends
     };
     rec.onend = () => {
@@ -164,13 +166,17 @@ export function useSpeechSync(opts: { text: string; lang?: string; enabled?: boo
 
     recRef.current = rec;
     setListening(true);
-    try { rec.start(); } catch {}
+    try { rec.start(); } catch (err) {
+      console.error("Failed to start speech recognition", err);
+    }
   }, [enabled, lang, textTokens, windowRadius]);
 
   const stop = useCallback(() => {
     const rec = recRef.current;
     if (rec) {
-      try { rec.stop(); } catch {}
+      try { rec.stop(); } catch (err) {
+        console.error("Failed to stop speech recognition", err);
+      }
     }
     recRef.current = null;
     setListening(false);

--- a/lib/textConverters.test.ts
+++ b/lib/textConverters.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { rtfToText, srtToText, mdToText } from './textConverters';
+
+test('rtfToText converts basic RTF', () => {
+  const input = "{\\rtf1\\ansi\\deff0 {\\b Bold} \\par Line}";
+  assert.equal(rtfToText(input), 'Bold\nLine');
+});
+
+test('srtToText removes indices and timecodes', () => {
+  const input = `1\n00:00:01,000 --> 00:00:02,000\nHello\n\n2\n00:00:03,000 --> 00:00:04,000\nWorld`;
+  assert.equal(srtToText(input), 'Hello\n\nWorld');
+});
+
+test('mdToText strips markdown syntax', () => {
+  const input = '# Title\nSome *emphasis* and [link](http://example.com).';
+  assert.equal(mdToText(input), 'Title\nSome emphasis and link.');
+});

--- a/lib/textConverters.ts
+++ b/lib/textConverters.ts
@@ -1,0 +1,77 @@
+function hexToChar(_: string, h: string) {
+  try {
+    return String.fromCharCode(parseInt(h, 16));
+  } catch (err) {
+    console.error('Invalid hex escape', err);
+    return "";
+  }
+}
+
+export function rtfToText(rtf: string) {
+  // Decode hex escapes first (\'hh)
+  let s = rtf.replace(/\\'([0-9a-fA-F]{2})/g, hexToChar);
+  // Map structural controls to whitespace before stripping
+  s = s
+    .replace(/\\par[d]?\b/g, "\n")
+    .replace(/\\line\b/g, "\n")
+    .replace(/\\tab\b/g, "\t");
+  // Unescape special chars
+  s = s.replace(/\\\\/g, "\\").replace(/\\\{/g, "{").replace(/\\\}/g, "}");
+  // Drop remaining control words (e.g., \b, \fs24, \cf1)
+  s = s.replace(/\\[a-zA-Z]+-?\d* ?/g, "");
+  // Remove groups braces
+  s = s.replace(/[{}]/g, "");
+  // Normalize whitespace
+  s = s.replace(/\r\n?|\r/g, "\n");
+  s = s.replace(/[\t ]+\n/g, "\n");
+  s = s.replace(/\n[\t ]+/g, "\n");
+  s = s.replace(/\n{3,}/g, "\n\n");
+  return s.trim();
+}
+
+export function srtToText(srt: string) {
+  const lines = srt.split(/\r?\n/);
+  const out: string[] = [];
+  const timeRe = /^\s*\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/;
+  for (const line of lines) {
+    if (/^\s*\d+\s*$/.test(line)) continue; // index line
+    if (timeRe.test(line)) continue; // timecode line
+    out.push(line);
+  }
+  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export function mdToText(md: string) {
+  let s = md;
+  // Remove code fences and inline code ticks (keep content inline)
+  s = s.replace(/```[\s\S]*?```/g, (m) => m.replace(/```/g, ""));
+  s = s.replace(/`([^`]*)`/g, "$1");
+  // Images: ![alt](url) -> alt
+  s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+  // Links: [text](url) -> text
+  s = s.replace(/\[([^\]]+)\]\((?:[^)]+)\)/g, "$1");
+  // Headings: #### Title -> Title
+  s = s.replace(/^\s{0,3}#{1,6}\s+/gm, "");
+  // Blockquotes: > text -> text
+  s = s.replace(/^\s{0,3}>\s?/gm, "");
+  // Lists: -/*/+ or 1. -> text
+  s = s.replace(/^\s{0,3}([*+-]|\d+\.)\s+/gm, "");
+  // Emphasis/strong/strike: *text* **text** _text_ __text__ ~~text~~ -> text
+  s = s.replace(/([*_~]{1,2})([^*_~]+)\1/g, "$2");
+  // Horizontal rules
+  s = s.replace(/^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/gm, "");
+  // Strip simple HTML tags
+  s = s.replace(/<[^>]+>/g, "");
+  // Normalize whitespace
+  s = s.replace(/\r\n?|\r/g, "\n").replace(/\n{3,}/g, "\n\n");
+  return s.trim();
+}
+
+export async function extractTextFromFile(file: File): Promise<string> {
+  const raw = await file.text();
+  const name = file.name.toLowerCase();
+  if (name.endsWith(".rtf")) return rtfToText(raw);
+  if (name.endsWith(".srt")) return srtToText(raw);
+  if (name.endsWith(".md") || name.endsWith(".markdown")) return mdToText(raw);
+  return raw;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "tsc lib/textConverters.ts lib/textConverters.test.ts --module commonjs --target ES2017 --esModuleInterop --outDir .tmp && node --test .tmp/textConverters.test.js && rm -rf .tmp"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/public/samples/en.txt
+++ b/public/samples/en.txt
@@ -1,0 +1,68 @@
+Ladies and Gentlemen,
+it is a great pleasure to address you today about the work carried out by APPLiA.
+
+APPLiA is the association representing the home appliance industry in Europe.
+Our sector directly employs more than 200,000 people,
+and indirectly supports millions of jobs across the value chain.
+
+Our mission is simple yet ambitious:
+to promote innovation, sustainability, and competitiveness.
+
+We work every day with European institutions,
+with national governments, and with civil society organizations.
+Our goal is to bring the voice of an essential sector,
+one that touches the everyday life of hundreds of millions of European citizens.
+
+Today, I would like to focus on a specific segment:
+cooling appliances.
+
+The global demand for these products is rapidly increasing.
+There are many reasons for this:
+the growth of the world’s population,
+the rising living standards in many emerging regions,
+and of course, climate change,
+which brings longer and hotter summers.
+
+Looking at Europe,
+we see similar trends, but also some unique characteristics.
+On the one hand, European consumers ask for ever more efficient appliances,
+capable of reducing energy consumption and household bills.
+On the other hand, European legislators set strict standards,
+to ensure both safety and environmental sustainability.
+
+It is therefore necessary to consider the legislative framework.
+The F-gas regulation, for example,
+imposes significant restrictions on the use of fluorinated gases,
+which are essential to the functioning of many cooling systems.
+
+Another sensitive topic concerns PFAS,
+the so-called “forever chemicals”.
+The idea of a full ban raises important questions,
+as many industrial applications still lack viable alternatives.
+
+Yet, there are also positive perspectives.
+The RePower EU plan, for instance,
+accelerates the energy transition,
+creating opportunities for more efficient appliances
+and for innovative technologies to reduce overall emissions.
+
+In such a complex environment,
+what is the way forward for an association like APPLiA?
+
+Our answer is clear:
+a constant dialogue with institutions,
+a collaborative approach with all stakeholders,
+and a firm commitment to ensure that sustainability goes hand in hand with competitiveness.
+
+Defending European manufacturing does not mean asking for protectionism.
+It means creating a level playing field,
+where European companies can continue to invest in innovation and employment.
+
+Our sector has shown its ability to adapt,
+to invest in digitalisation and in energy efficiency,
+and it will continue to do so.
+
+APPLiA will remain by the side of institutions and citizens,
+to build together a greener, safer, and more prosperous future for Europe.
+
+Thank you for your attention.

--- a/public/samples/it.txt
+++ b/public/samples/it.txt
@@ -1,0 +1,69 @@
+Signore e Signori,
+è con grande piacere che vi parlo oggi del lavoro che svolge APPLiA.
+
+APPLiA è l’associazione che rappresenta l’industria degli elettrodomestici in Europa.
+Il nostro settore impiega direttamente oltre 200.000 persone,
+e indirettamente sostiene milioni di posti di lavoro lungo la catena del valore.
+
+La nostra missione è semplice ma ambiziosa:
+promuovere l’innovazione, la sostenibilità e la competitività delle imprese europee.
+
+Lavoriamo ogni giorno con le istituzioni europee,
+con i governi nazionali, e con le organizzazioni della società civile.
+Il nostro obiettivo è portare la voce di un settore essenziale,
+che accompagna la vita quotidiana di centinaia di milioni di cittadini europei.
+
+Oggi desidero concentrare la mia attenzione su un segmento specifico:
+gli apparecchi di raffreddamento, o cooling appliances.
+
+La domanda globale di questi prodotti è in forte crescita.
+Le ragioni sono molteplici:
+l’aumento della popolazione mondiale,
+il miglioramento del livello di vita in numerose regioni emergenti,
+e naturalmente il cambiamento climatico,
+che porta a estati sempre più calde e prolungate.
+
+Guardando all’Europa,
+possiamo osservare tendenze simili ma con alcune peculiarità.
+Da un lato, i consumatori europei chiedono apparecchi sempre più efficienti,
+che riducano i consumi energetici e le bollette.
+Dall’altro lato, i legislatori europei fissano standard molto severi,
+per garantire la sicurezza e la sostenibilità ambientale.
+
+Ed è proprio sul quadro legislativo che dobbiamo soffermarci.
+La normativa sugli F-gas, ad esempio,
+impone restrizioni significative sull’uso di gas fluorurati,
+fondamentali per il funzionamento di molti sistemi di raffreddamento.
+
+Un altro fronte delicato riguarda i PFAS,
+le cosiddette “sostanze per sempre”.
+L’ipotesi di un divieto totale solleva interrogativi importanti,
+perché molte applicazioni industriali ancora non dispongono di alternative valide.
+
+Tuttavia, vi sono anche prospettive positive.
+Il piano RePower EU, ad esempio,
+spinge verso un’accelerazione della transizione energetica,
+offrendo opportunità per apparecchi più efficienti
+e per tecnologie innovative che possano ridurre le emissioni complessive.
+
+In questo contesto complesso,
+qual è la via da seguire per un’associazione come APPLiA?
+
+La nostra risposta è chiara:
+dialogo costante con le istituzioni,
+collaborazione con tutte le parti interessate,
+e impegno per garantire che la sostenibilità vada di pari passo con la competitività.
+
+Difendere la produzione europea non significa chiedere protezionismo,
+ma creare un terreno equo in cui le aziende europee
+possano continuare a investire in innovazione e occupazione.
+
+Il nostro settore ha dimostrato di saper cambiare,
+di saper investire nella digitalizzazione e nell’efficienza energetica,
+e continuerà a farlo.
+
+APPLiA sarà sempre al fianco delle istituzioni e dei cittadini,
+per costruire insieme un futuro più verde,
+più sicuro e più prospero per l’Europa.
+
+Grazie per la vostra attenzione.


### PR DESCRIPTION
## Summary
- load demo speeches from external files and swap based on UI language
- extract text converters into a shared module with tests
- log failures for localStorage, ASR reset and fullscreen operations

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c597babb148330bce2edc43c0a02c7