### PR TITLE
Upgrade dependencies to patched React and Next.js releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "test": "tsc lib/text.ts lib/text.test.ts lib/textConverters.ts lib/textConverters.test.ts hooks/engineMath.ts hooks/engineMath.test.ts --module commonjs --target ES2017 --esModuleInterop --outDir .tmp && node --test .tmp/**/*.test.js && rm -rf .tmp"
   },
   "dependencies": {
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react": "19.1.2",
+    "react-dom": "19.1.2",
+    "next": "15.5.7"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -25,7 +25,7 @@
     "@tailwindcss/postcss": "^4",
     "tailwindcss": "^4",
     "eslint": "^9",
-    "eslint-config-next": "15.5.2",
+    "eslint-config-next": "15.5.7",
     "@eslint/eslintrc": "^3"
   }
 }


### PR DESCRIPTION
## Summary
- bump Next.js to 15.5.7 and React/React DOM to 19.1.2 to move onto patched releases
- align eslint-config-next with the updated Next.js patch level
- note: lockfile was not refreshed because registry access returned HTTP 403 in this environment

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355a8f009083308dc971c70296ce8a)